### PR TITLE
feat: Add rungroup v2 implementation

### DIFF
--- a/README.v1.md
+++ b/README.v1.md
@@ -1,0 +1,107 @@
+# rungroup
+A Go module for managing concurrent tasks with automatic cancellation when any task completes or fails.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/goaux/rungroup.svg)](https://pkg.go.dev/github.com/goaux/rungroup)
+[![Go Report Card](https://goreportcard.com/badge/github.com/goaux/rungroup)](https://goreportcard.com/report/github.com/goaux/rungroup)
+
+`rungroup` is a Go module that provides a way to manage and synchronize
+concurrent tasks. Its primary feature is the ability to cancel all goroutines
+when any one of them completes. This package is particularly useful for
+scenarios where you need to run multiple operations concurrently but want to
+stop all of them as soon as any one operation completes or fails.
+
+## Features
+
+- Manage multiple goroutines as a group
+- Automatic cancellation of all tasks when one completes
+- Support for timeouts
+- Easy-to-use API
+
+## Installation
+
+To install the `rungroup` module, use `go get`:
+
+```
+go get github.com/goaux/rungroup
+```
+
+## Usage
+
+Here's a basic example of how to use the `rungroup` module:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "github.com/goaux/rungroup"
+	"github.com/goaux/timer"
+)
+
+func main() {
+	// Create a new group with no timeout
+	rg := rungroup.New(context.Background())
+
+	// Add tasks to the group
+	rg.Go(func(ctx context.Context) error {
+		if err := timer.Sleep(ctx, 150*time.Millisecond); err != nil {
+			fmt.Println("task1 canceled")
+			return err
+		}
+		fmt.Println("task1 done")
+		return nil
+	})
+
+	rg.Go(func(ctx context.Context) error {
+		if err := timer.Sleep(ctx, 300*time.Millisecond); err != nil {
+			fmt.Println("task2 canceled")
+			return err
+		}
+		fmt.Println("task2 done")
+		return nil
+	})
+
+	// Wait for all tasks to complete or be canceled
+	err := rg.Wait()
+	if err != nil {
+		fmt.Printf("must not error: %v\n", err)
+	} else {
+		fmt.Println("ok")
+	}
+}
+```
+
+In this example, the first task completes after 150 milliseconds, which
+triggers the cancellation of the second task. The `Wait` method returns when
+all tasks have either completed or been canceled.
+
+## API
+
+### `New(ctx context.Context) *Group`
+
+Creates a new `Group` with the given context.
+
+### `NewTimeout(ctx context.Context, d time.Duration) *Group`
+
+Creates a new `Group` with the given context and timeout duration.
+
+### `(g *Group) Go(task func(context.Context) error)`
+
+Starts a new goroutine in the `Group`.
+
+### `(g *Group) Wait() error`
+
+Blocks until all tasks in the `Group` have completed or been canceled.
+
+### `(g *Group) Cancel()`
+
+Explicitly cancels the `Group`'s context, causing all tasks to be interrupted.
+
+## Note
+
+- A `Group` must be created by `New` or `NewTimeout`, zero value must not be used.
+- A `Group` must not be copied after first use.
+- A `Group` must not be reused after calling `Wait`.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/goaux/rungroup/v2 instead.
 module github.com/goaux/rungroup
 
 go 1.20

--- a/v2/LICENSE
+++ b/v2/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,0 +1,153 @@
+# rungroup/v2
+
+A Go module for managing and coordinating concurrent tasks with fine-grained control over cancellation.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/goaux/rungroup/v2.svg)](https://pkg.go.dev/github.com/goaux/rungroup/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/goaux/rungroup/v2)](https://goreportcard.com/report/github.com/goaux/rungroup/v2)
+
+`rungroup/v2` is a Go module that provides a robust mechanism for managing and coordinating a collection of goroutines. It allows you to start multiple tasks concurrently and coordinate their execution with fine-grained control over cancellation behavior.
+
+## Improvements over v1
+
+Version 2 of `rungroup` addresses several limitations present in v1:
+
+- **Non-terminating tasks**: v1 automatically triggered cancellation when any task completed. v2 allows tasks to run independently with explicit control over cancellation behavior.
+- **Error propagation**: v2 allows specifying an error when calling `Cancel`, providing more informative cancellation reasons.
+- **Zero value safety**: v1 panicked when used with a zero value. v2 is safe to use with zero values, automatically initializing with `context.Background`.
+- **Nested tasks**: v1 prevented starting new tasks within the same group from within a running task. v2 allows nested tasks to be started within the same group.
+
+## Installation
+
+To install the `rungroup/v2` module, use `go get`:
+
+```
+go get github.com/goaux/rungroup/v2
+```
+
+## Usage
+
+Here's a basic example of how to use the `rungroup/v2` module:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/goaux/rungroup/v2"
+	"github.com/goaux/stacktrace/v2"
+)
+
+func main() {
+	// Create a new group
+	gr := rungroup.New(context.Background())
+
+	// Ensure we clean up resources
+	defer gr.Close()
+
+	// Add a task that will finish after 150ms
+	gr.Go(func(ctx context.Context) {
+		select {
+		case <-time.After(150 * time.Millisecond):
+			fmt.Println("Task 1 completed")
+		case <-ctx.Done():
+			fmt.Println("Task 1 canceled")
+		}
+	})
+
+	// Add a task that will finish after 300ms
+	// This task will only be canceled if explicitly requested
+	gr.Go(func(ctx context.Context) {
+		select {
+		case <-time.After(300 * time.Millisecond):
+			fmt.Println("Task 2 completed")
+		case <-ctx.Done():
+			fmt.Println("Task 2 canceled")
+		}
+	})
+
+	// Add a task that will cancel the group on completion
+	gr.GoCancelOnFinish(func(ctx context.Context) error {
+		time.Sleep(100 * time.Millisecond)
+		fmt.Println("Task 3 completed, canceling group")
+		return nil
+	})
+
+	// Wait for all tasks to complete or be canceled
+	err := gr.Wait()
+	if err != nil {
+		fmt.Printf("Group canceled with error: %v\n", stacktrace.Format(err))
+	} else {
+		fmt.Println("All tasks completed successfully")
+	}
+}
+```
+
+## API Overview
+
+### Creating a Group
+
+```go
+// Create a new Group with a parent context
+gr := rungroup.New(ctx)
+
+// A zero value is also valid
+var gr rungroup.Group
+```
+
+### Starting Tasks
+
+```go
+// Start a task without automatic cancellation
+gr.Go(func(ctx context.Context) {
+    // Your task logic here
+})
+
+// Start a task that cancels the group when it completes (success or failure)
+gr.GoCancelOnFinish(func(ctx context.Context) error {
+    // Your task logic here
+    return nil
+})
+
+// Start a task that cancels the group only on successful completion
+gr.GoCancelOnSuccess(func(ctx context.Context) error {
+    // Your task logic here
+    return nil
+})
+
+// Start a task that cancels the group only on error
+gr.GoCancelOnError(func(ctx context.Context) error {
+    // Your task logic here
+    return errors.New("task failed")
+})
+```
+
+### Controlling the Group
+
+```go
+// Cancel the group with a specific error
+gr.Cancel(errors.New("operation aborted"))
+
+// Cancel the group with ErrClosed
+gr.Close()
+
+// Set a timeout for the group
+gr.SetTimeout(5 * time.Second)
+
+// Wait for all tasks to complete
+err := gr.Wait()
+```
+
+## Resource Management
+
+It's important to call either `gr.Close()` or `gr.Cancel()` when a Group is no longer needed to prevent resource leaks. This applies to both Groups created with `New()` and zero-value Groups.
+
+## Thread Safety
+
+`rungroup/v2` is designed to be thread-safe. You can start tasks from multiple goroutines, including from within other tasks in the same group.
+
+## License
+
+[Apache License Version 2.0](LICENSE)

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,8 @@
+module github.com/goaux/rungroup/v2
+
+go 1.20
+
+require (
+	github.com/goaux/stacktrace/v2 v2.3.1
+	github.com/goaux/waitgroup v1.0.0
+)

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,0 +1,4 @@
+github.com/goaux/stacktrace/v2 v2.3.1 h1:rUqaUKLkHVNJ8trK4sdmETIcisKk985Sh8tTZC7DZeY=
+github.com/goaux/stacktrace/v2 v2.3.1/go.mod h1:WT0j+ibEaqyL8LiVI69FlMcGirtjCg92nXj/YT/vfCM=
+github.com/goaux/waitgroup v1.0.0 h1:XD05UPRMOeIJUuXgtrdE3Ef6enhNA2v6WLG4or7kKEA=
+github.com/goaux/waitgroup v1.0.0/go.mod h1:24sreE5Xf94gyQ3TCNgeaWU2ywxaZkIlEW9DU2oRg0A=

--- a/v2/group.go
+++ b/v2/group.go
@@ -1,0 +1,226 @@
+// Package rungroup provides a mechanism for managing and coordinating a collection of goroutines.
+//
+// It allows you to start multiple goroutines and wait for them to finish, with
+// options for canceling other goroutines based on the completion or failure of
+// a specific task.
+//
+// Key features include:
+//
+//   - Starting goroutines with [Group.Go], [Group.GoCancelOnFinish],
+//     [Group.GoCancelOnSuccess], and [Group.GoCancelOnError].
+//   - Waiting for all goroutines to finish with [Group.Wait].
+//   - Canceling all goroutines with [Group.Cancel] or [Group.Close].
+//   - Setting a timeout for the group with [Group.SetTimeout].
+//
+// This package is useful for scenarios where you need to execute multiple
+// tasks concurrently and ensure that they are properly managed and
+// coordinated.
+//
+// # Improvement over v1
+//
+// v2 aimed for the simplest possible implementation, prioritizing minimalism
+// over feature richness.
+//
+// However, this simplicity was achieved without sacrificing essential
+// functionality or addressing key limitations present in v1.
+//
+// The following improvements were made:
+//
+//   - Non-terminating tasks:
+//     v1 lacked the ability to start a task without automatically triggering
+//     cancellation of other tasks. v2 allows tasks to run independently.
+//   - Error propagation:
+//     v1 did not allow specifying an error when calling `Cancel`. v2 allows
+//     errors to be passed to `Cancel` for more informative cancellation.
+//   - Zero value safety:
+//     v1 panicked when used with a zero value. v2 is safe to use with zero
+//     values, initializing with `context.Background`.
+//   - Nested tasks:
+//     v1 prevented starting new tasks within the same group from within a
+//     running task. v2 allows nested tasks to be started within the same
+//     group.
+package rungroup
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/goaux/stacktrace/v2"
+	"github.com/goaux/waitgroup"
+)
+
+// ErrClosed is used as the argument when [Group.Close] calls [Group.Cancel].
+// If, for a [Group], this call to [Group.Cancel] is the first call to [Group.Cancel],
+// then [Group.Wait] will return ErrClosed.
+var ErrClosed = errors.New("closed")
+
+// A Group waits for a collection of goroutines to finish.
+//
+// The main goroutine calls [Group.Go], [Group.GoCancelOnFinish],
+// [Group.GoCancelOnSuccess], and [Group.GoCancelOnError] to start a new
+// goroutine. Then, each of the goroutines runs and can call [Group.Cancel] if
+// desired. At the same time, [Group.Wait] can be used to block until all
+// goroutines have finished.
+//
+// It is possible to use zero values.
+type Group struct {
+	mu sync.Mutex
+	g  waitgroup.Sync
+
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+}
+
+// New returns a Group initialized with parent as its parent context.
+//
+// The initialized [Group] must have [Group.Close] or [Group.Cancel] called to
+// release its resources when it is no longer needed. This is crucial to
+// prevent resource leaks.
+//
+// A zero-valued Group is initialized with [context.Background] as its parent
+// context. Importantly, even a zero-valued Group must have [Group.Close] or
+// [Group.Cancel] called when it's no longer needed, just like a Group created
+// with `New`. Failing to do so will result in a resource leak.
+func New(parent context.Context) *Group {
+	ctx, cancel := context.WithCancelCause(parent)
+	return &Group{ctx: ctx, cancel: cancel}
+}
+
+// Close cancels the [Group] by calling [Group.Cancel] with [ErrClosed],
+// thereby releasing its associated resources.
+func (gr *Group) Close() {
+	gr.Cancel(stacktrace.NewError(ErrClosed, stacktrace.Callers(1)))
+}
+
+// Cancel cancels the context for a [Group].
+//
+// The cause of cancellation is recorded in the context on the first Cancel
+// call for each [Group] instance, and can be retrieved via [context.Cause].
+func (gr *Group) Cancel(cause error) {
+	gr.getContext()
+	if cause == nil {
+		cause = context.Canceled
+	}
+	gr.cancel(stacktrace.NewError(cause, stacktrace.Callers(1)))
+}
+
+// Wait blocks until all goroutines have exited.
+// It returns the argument passed to the first [Group.Cancel] call, or nil if
+// [Group.Cancel] was never called.
+func (gr *Group) Wait() error {
+	gr.getContext()
+	gr.g.Wait()
+	return context.Cause(gr.ctx)
+}
+
+// getContext returns the context for the [Group].
+// The context associated with the [Group] will be cancelled when [Group.Cancel] is invoked.
+func (gr *Group) getContext() context.Context {
+	gr.mu.Lock()
+	defer gr.mu.Unlock()
+	if gr.ctx == nil {
+		gr.ctx, gr.cancel = context.WithCancelCause(context.Background())
+	}
+	return gr.ctx
+}
+
+// Go allows you to start a task in a new goroutine and synchronize its
+// completion with a [Group].
+//
+// The completion of a task does not automatically cancel the [Group]'s context.
+// You must explicitly call [Group.Cancel] to cancel the [Group]'s context.
+//
+// Or, methods are available to call [Group.Cancel] upon task completion.
+//
+//   - GoCancelOnFinish: Calls [Group.Cancel] when the task finishes (regardless of success or error).
+//   - GoCancelOnSuccess: Calls [Group.Cancel] when the task completes successfully.
+//   - GoCancelOnError: Calls [Group.Cancel] when the task completes with an error.
+//
+// These methods are essentially macros around [Group.Go], internally calling
+// both [Group.Go] and [Group.Cancel].
+//
+// The [Group]'s context is passed to the task.
+// When [Group.Cancel] is called, the [Group]'s context is cancelled.
+func (gr *Group) Go(task func(context.Context)) {
+	ctx := gr.getContext()
+	gr.g.Go(func() { task(ctx) })
+}
+
+// SetTimeout cancels the group's context after the timeout duration has elapsed.
+//
+// The cancellation is performed by calling [Group.Cancel] with
+// [context.DeadlineExceeded] as the argument. If the [Group]'s context is
+// canceled before the timeout, [Group.Cancel] is not called.
+func (gr *Group) SetTimeout(timeout time.Duration) {
+	ctx := gr.getContext()
+	callers := stacktrace.Callers(1)
+	go func() {
+		t := time.NewTimer(timeout)
+		defer t.Stop()
+		select {
+		case <-t.C:
+			gr.cancel(stacktrace.NewError(context.DeadlineExceeded, callers))
+		case <-ctx.Done():
+		}
+	}()
+}
+
+// GoCancelOnFinish starts a task using [Group.Go] and, when that task
+// finishes, cancels all other running tasks in the group using [Group.Cancel].
+//
+// Use Cases:
+//
+// Use this when completing one task makes other tasks unnecessary.
+//
+// For example, imagine a primary task and several helper tasks. If the primary
+// task completes, you might want to stop the helpers immediately.
+func (gr *Group) GoCancelOnFinish(task func(context.Context) error) {
+	callers := stacktrace.Callers(1)
+	gr.Go(func(ctx context.Context) {
+		err := task(ctx)
+		if err == nil {
+			err = context.Canceled
+		}
+		gr.cancel(stacktrace.NewError(err, callers))
+	})
+}
+
+// GoCancelOnSuccess starts a task using [Group.Go] and, if the task completes
+// successfully (returns a nil error), cancels all other running tasks in the
+// group by calling [Group.Cancel] with an argument [context.Canceled].
+//
+// Use Cases:
+//
+// This is helpful when finishing one task makes other tasks unnecessary.
+//
+// For example, imagine you have several tasks doing the same thing in
+// different ways. You'd want to use the result from the task that finishes
+// first.
+func (gr *Group) GoCancelOnSuccess(task func(context.Context) error) {
+	callers := stacktrace.Callers(1)
+	gr.Go(func(ctx context.Context) {
+		if err := task(ctx); err == nil { // if NO error
+			gr.cancel(stacktrace.NewError(context.Canceled, callers))
+		}
+	})
+}
+
+// GoCancelOnError calls [Group.Go] to start a task, and if the task returns a
+// non-nil error, it calls [Group.Cancel] with that error as the argument.
+//
+// Use Cases:
+//
+// Use this when one task failing means other tasks can't finish.
+//
+// Imagine a big task split into smaller parts done at the same time. If one
+// part fails, you can't complete the whole thing.
+func (gr *Group) GoCancelOnError(task func(context.Context) error) {
+	callers := stacktrace.Callers(1)
+	gr.Go(func(ctx context.Context) {
+		if err := task(ctx); err != nil {
+			gr.cancel(stacktrace.NewError(err, callers))
+		}
+	})
+}

--- a/v2/group_test.go
+++ b/v2/group_test.go
@@ -1,0 +1,205 @@
+package rungroup_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	rungroup "github.com/goaux/rungroup/v2"
+)
+
+func Example() {
+	n := int32(0)
+	var gr rungroup.Group // It is possible to use zero values.
+	defer gr.Close()
+	gr.Go(func(context.Context) { atomic.AddInt32(&n, 1) })
+	gr.Go(func(context.Context) { atomic.AddInt32(&n, 1) })
+	err := gr.Wait()
+	fmt.Println(n, err)
+	// Output:
+	// 2 <nil>
+}
+
+func ExampleGroup_cancel() {
+	n := int32(0)
+	var gr rungroup.Group
+	defer gr.Close()
+	gr.Go(func(ctx context.Context) { gr.Cancel(fmt.Errorf("testing")); atomic.AddInt32(&n, 1) })
+	gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+	err := gr.Wait()
+	fmt.Println(n, err)
+	// Output:
+	// 2 testing (group_test.go:30 ExampleGroup_cancel.func1)
+}
+
+func ExampleGroup_setTimeout() {
+	n := int32(0)
+	var gr rungroup.Group
+	defer gr.Close()
+	gr.SetTimeout(time.Millisecond)
+	gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+	gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+	err := gr.Wait()
+	fmt.Println(n, err)
+	// Output:
+	// 2 context deadline exceeded (group_test.go:42 ExampleGroup_setTimeout)
+}
+
+func TestNew(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		n := int32(0)
+		gr := rungroup.New(context.TODO())
+		defer gr.Close()
+		gr.Go(func(context.Context) { atomic.AddInt32(&n, 1) })
+		gr.Go(func(context.Context) { atomic.AddInt32(&n, 1) })
+		err := gr.Wait()
+		assertNoError(t, err)
+		assertEqual(t, n, 2)
+	})
+
+	t.Run("cancel parent", func(t *testing.T) {
+		parent, cancelParent := context.WithCancel(context.TODO())
+		n := int32(0)
+		gr := rungroup.New(parent)
+		defer gr.Close()
+		gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+		gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+		cancelParent()
+		err := gr.Wait()
+		assertErrorIs(t, err, context.Canceled)
+		assertEqual(t, n, 2)
+	})
+}
+
+func TestGroup(t *testing.T) {
+	t.Run("Close", func(t *testing.T) {
+		var gr rungroup.Group
+		gr.Close()
+		err := gr.Wait()
+		assertErrorIs(t, err, rungroup.ErrClosed)
+	})
+
+	t.Run("Cancel", func(t *testing.T) {
+		n := int32(0)
+		gr := rungroup.New(context.TODO())
+		defer gr.Close()
+		gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+		gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+		gr.Cancel(nil)
+		err := gr.Wait()
+		assertErrorIs(t, err, context.Canceled)
+		assertEqual(t, n, 2)
+	})
+
+	t.Run("nested start", func(t *testing.T) {
+		n := int32(0)
+		var gr rungroup.Group
+		defer gr.Close()
+		gr.Go(func(context.Context) {
+			gr.Go(func(context.Context) {
+				atomic.AddInt32(&n, 1)
+			})
+			atomic.AddInt32(&n, 1)
+		})
+		err := gr.Wait()
+		assertNoError(t, err)
+		assertEqual(t, n, 2)
+	})
+
+	ErrStop := errors.New("stop")
+
+	t.Run("GoCnacelOnFinish", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			n := int32(0)
+			var gr rungroup.Group
+			defer gr.Close()
+			gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+			gr.GoCancelOnFinish(func(ctx context.Context) error { atomic.AddInt32(&n, 1); return nil })
+			err := gr.Wait()
+			assertErrorIs(t, err, context.Canceled)
+			assertEqual(t, n, 2)
+		})
+		t.Run("error", func(t *testing.T) {
+			n := int32(0)
+			var gr rungroup.Group
+			defer gr.Close()
+			gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+			gr.GoCancelOnFinish(func(ctx context.Context) error { atomic.AddInt32(&n, 1); return ErrStop })
+			err := gr.Wait()
+			assertErrorIs(t, err, ErrStop)
+			assertEqual(t, n, 2)
+		})
+	})
+
+	t.Run("GoCancelOnSuccess", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			n := int32(0)
+			var gr rungroup.Group
+			defer gr.Close()
+			gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+			gr.GoCancelOnSuccess(func(ctx context.Context) error { atomic.AddInt32(&n, 1); return nil })
+			err := gr.Wait()
+			assertErrorIs(t, err, context.Canceled)
+			assertEqual(t, n, 2)
+		})
+		t.Run("error", func(t *testing.T) {
+			n := int32(0)
+			var gr rungroup.Group
+			defer gr.Close()
+			gr.Go(func(ctx context.Context) { atomic.AddInt32(&n, 1) })
+			gr.GoCancelOnSuccess(func(ctx context.Context) error { atomic.AddInt32(&n, 1); return ErrStop })
+			err := gr.Wait()
+			assertNoError(t, err)
+			assertEqual(t, n, 2)
+		})
+	})
+
+	t.Run("GoCancelOnError", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			n := int32(0)
+			var gr rungroup.Group
+			defer gr.Close()
+			gr.Go(func(ctx context.Context) { atomic.AddInt32(&n, 1) })
+			gr.GoCancelOnError(func(ctx context.Context) error { atomic.AddInt32(&n, 1); return nil })
+			err := gr.Wait()
+			assertNoError(t, err)
+			assertEqual(t, n, 2)
+		})
+		t.Run("error", func(t *testing.T) {
+			n := int32(0)
+			var gr rungroup.Group
+			defer gr.Close()
+			gr.Go(func(ctx context.Context) { <-ctx.Done(); atomic.AddInt32(&n, 1) })
+			gr.GoCancelOnError(func(ctx context.Context) error { atomic.AddInt32(&n, 1); return ErrStop })
+			err := gr.Wait()
+			assertErrorIs(t, err, ErrStop)
+			assertEqual(t, n, 2)
+		})
+	})
+}
+
+// assertEqual calls t.Error if got is not equal to want.
+func assertEqual[T comparable](t *testing.T, actual, expect T, msg ...any) {
+	t.Helper()
+	if actual != expect {
+		t.Error(fmt.Sprintf("must equal; actual=%v, expect=%v", actual, expect), fmt.Sprint(msg...))
+	}
+}
+
+// assertNoError calls t.Error if actual is not nil.
+func assertNoError(t *testing.T, actual error, msg ...any) {
+	t.Helper()
+	if actual != nil {
+		t.Error(fmt.Sprintf("must be nil, actual=%#v", actual), fmt.Sprint(msg...))
+	}
+}
+
+func assertErrorIs(t *testing.T, actual, expect error, msg ...any) {
+	t.Helper()
+	if !errors.Is(actual, expect) {
+		t.Error(fmt.Sprintf("actual=%#v, expect=%#v", actual, expect), fmt.Sprint(msg...))
+	}
+}


### PR DESCRIPTION
Implement a new `rungroup` v2 package, offering a simplified and more robust solution for managing goroutines. This version addresses limitations in v1, including support for non-terminating tasks, improved error propagation, zero-value safety, and nested tasks.

Key improvements include:

- **Non-terminating tasks:**
  - Allows tasks to run independently without automatically triggering cancellation.
- **Error propagation:**
  - Enables passing errors to `Cancel` for more informative cancellation.
- **Zero-value safety:**
  - Handles zero values safely, initializing with `context.Background`
- **Nested tasks:**
  - Supports starting new tasks within the same group from within a running task.

This implementation prioritizes minimalism and addresses key limitations present in v1, providing a more reliable and flexible solution for coordinating goroutines.  Includes comprehensive tests for core functionality and edge cases.